### PR TITLE
single_right_rotation() method is defined and implemented in AVLTree …

### DIFF
--- a/src/avl_tree.cpp
+++ b/src/avl_tree.cpp
@@ -29,6 +29,20 @@ template <typename ValType> AVLTree<ValType>::AVLTree() {
   num_of_nodes_ = 0;
 }
 
+/* root - left - left */
+/* when cur_node's left child has bigger height than right child's height and
+ * newly insterted node has smaller key than left child's one */
+template <typename ValType>
+Node<ValType> *
+AVLTree<ValType>::single_right_rotation(Node<ValType> *cur_node) {
+  Node<ValType> *left_child = cur_node->left_;
+  cur_node->left_ = left_child->right_;
+  left_child->right_ = cur_node;
+  set_height(cur_node, 3);
+  set_height(left_child, 1);
+  return left_child;
+}
+
 /*
 set_hegiht based on calling node's childs
 children argument

--- a/src/avl_tree.cpp
+++ b/src/avl_tree.cpp
@@ -31,7 +31,7 @@ template <typename ValType> AVLTree<ValType>::AVLTree() {
 
 /* root - left - left */
 /* when cur_node's left child has bigger height than right child's height and
- * newly insterted node has smaller key than left child's one */
+   inserted node has smaller key than left child's one */
 template <typename ValType>
 Node<ValType> *
 AVLTree<ValType>::single_right_rotation(Node<ValType> *cur_node) {

--- a/src/avl_tree.h
+++ b/src/avl_tree.h
@@ -31,6 +31,8 @@ template <typename ValType> class AVLTree {
 protected:
   // AVLTree constructor
   AVLTree();
+  // Single righr rotation
+  Node<ValType> *single_right_rotation(Node<ValType> *);
   // set height of a given node
   void set_height(Node<ValType> *, int);
   // get height of a given node


### PR DESCRIPTION
single_right_rotation() 멤버 함수가 AVLTree에 선언, 구현 되었습니다.

해당 기능은 cur_node 기준으로 right 자식, right 자식의 자식 형태인 right skewed tree 형태를 띠며, cur_node의 right, left child의 height 차이가 2라면 호출될 겁니다.