### PR TITLE
is_balanced() is defiend and implented in AVTree class

### DIFF
--- a/src/avl_tree.cpp
+++ b/src/avl_tree.cpp
@@ -43,6 +43,13 @@ AVLTree<ValType>::single_right_rotation(Node<ValType> *cur_node) {
   return left_child;
 }
 
+/* difference between heights have to be less than 2 to be balanced. */
+template <typename ValType>
+bool AVLTree<ValType>::is_balanced(Node<ValType> *child_1,
+                                   Node<ValType> *child_2) {
+  return (get_height(child_1) - get_height(child_2) < 2);
+}
+
 /*
 set_hegiht based on calling node's childs
 children argument

--- a/src/avl_tree.h
+++ b/src/avl_tree.h
@@ -33,6 +33,8 @@ protected:
   AVLTree();
   // Single righr rotation
   Node<ValType> *single_right_rotation(Node<ValType> *);
+  // check if AVL tree is balanced
+  bool is_balanced(Node<ValType> *, Node<ValType> *);
   // set height of a given node
   void set_height(Node<ValType> *, int);
   // get height of a given node


### PR DESCRIPTION
is_balanced() 멤버를 AVLTree 클래스에 추가하고 구현하였습니다.

해당 함수는 Node* 를 전달받으며, Node* 기준으로 자식의 height 차이가 2 미만인지 검사합니다.

2 미만이면 1, 아니면 0을 반환합니다. 이 때 insert_node() 멤버에서 rotation을 요구합니다.