### PR TITLE
insert_node() in AVLTree is defined and implemented, and compilation error resolved 

### DIFF
--- a/src/avl_tree.cpp
+++ b/src/avl_tree.cpp
@@ -91,3 +91,6 @@ int AVLTree<ValType>::get_height(Node<ValType> *cur_node) {
     return cur_node->get_height();
   }
 }
+
+template class AVLTree<int>;
+template class Node<int>;

--- a/src/avl_tree.h
+++ b/src/avl_tree.h
@@ -31,6 +31,8 @@ template <typename ValType> class AVLTree {
 protected:
   // AVLTree constructor
   AVLTree();
+  // insert a node
+  Node<ValType> *insert_node(Node<ValType> *, ValType);
   // Single righr rotation
   Node<ValType> *single_right_rotation(Node<ValType> *);
   // check if AVL tree is balanced

--- a/src/insert.cpp
+++ b/src/insert.cpp
@@ -1,0 +1,70 @@
+/*
+File: insert.cpp
+Copyright (c) 2023 김기정
+
+MIT License
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+#include "avl_tree.h"
+
+/*
+    insert a node storing a given key to AVL tree
+    1. this function traverse nodes recursively from root untill it meets
+   NULL(leaf).
+    2. then, check if tree is balanced at each node this function traversed.
+*/
+
+template <typename ValType>
+Node<ValType> *AVLTree<ValType>::insert_node(Node<ValType> *cur_node,
+                                             ValType key) {
+
+  /* if meets leaf(NULL), make a new node */
+  if (cur_node == NULL) {
+    cur_node = new Node<ValType>(key);
+  }
+
+  /* if new key is smaller than current node's key, become a left child */
+  else if (cur_node->key_ > key) {
+    cur_node->left_ = insert_node(cur_node->left_, key);
+    /* balancing */
+    if (!is_balanced(cur_node->left_, cur_node->right_)) {
+      if (cur_node->left_->key_ > key) {
+        cur_node = single_right_rotation(cur_node);
+      } else {
+      }
+    }
+  }
+
+  /* if new key is bigger than current node's key, become a right child */
+  else {
+    cur_node->right_ = insert_node(cur_node->right_, key);
+    if (!is_balanced(cur_node->right_, cur_node->left_)) {
+      if (cur_node->right_->key_ < key) {
+
+      } else {
+      }
+    }
+  }
+
+  /* set height of current node */
+  set_height(cur_node, 3);
+  return cur_node;
+}
+
+template class AVLTree<int>;
+template class Node<int>;

--- a/src/node.cpp
+++ b/src/node.cpp
@@ -47,3 +47,5 @@ template <typename ValType> void Node<ValType>::set_height(int height) {
 }
 
 template <typename ValType> int Node<ValType>::get_height() { return height_; }
+
+template class Node<int>;

--- a/src/node.h
+++ b/src/node.h
@@ -23,10 +23,13 @@ SOFTWARE.
 
 #ifndef NODE_H
 #define NODE_H
+
+template <typename ValType> class AVLTree;
+
 // define Node
 template <typename ValType>
 class Node {
-  friend class AVLTree;
+  friend class AVLTree<ValType>;
   friend class Set;
 
 private:


### PR DESCRIPTION
AVLTree의 insert_node() 함수 추가, 구현하였습니다.

그리고 make로 컴파일 했을 때, undefined reference 에러가 발생하여, node.cpp, insert.cpp, avl_tree.cpp 하단에 "template class AVLTree<int>, template class Node<int>" 구문을 추가하였습니다. node.h에도 AVLTree가 template class임을 알리는 "template <typename ValType> class AVLTree" 구문을 추가하였습니다.

해당 에러는 class에 template를 사용했을 때 자주 발생하는 에러입니다. 

에러 구문은 다음과 같습니다.
undefined reference to 'name of method'