### PR TITLE
changed single rotation methods and tested via domjudge

### DIFF
--- a/src/avl_tree.cpp
+++ b/src/avl_tree.cpp
@@ -29,7 +29,7 @@ template <typename ValType> AVLTree<ValType>::AVLTree() {
   num_of_nodes_ = 0;
 }
 
-/* root - left - left */
+//* root - left - left */
 /* when cur_node's left child has bigger height than right child's height and
    inserted node has smaller key than left child's one */
 template <typename ValType>
@@ -39,7 +39,10 @@ Node<ValType> *AVLTree<ValType>::SingleRightRotation(Node<ValType> *cur_node) {
   left_child->right_ = cur_node;
   SetHeight(cur_node, 3);
   cur_node->size_ = GetSize(cur_node->left_) + GetSize(cur_node->right_) + 1;
-  SetHeight(left_child, 1);
+  left_child->height_ = (GetHeight(left_child->left_) > cur_node->height_
+                             ? GetHeight(left_child->left_)
+                             : cur_node->height_) +
+                        1; //
   left_child->size_ = GetSize(left_child->left_) + cur_node->size_ + 1;
   return left_child;
 }
@@ -54,7 +57,10 @@ Node<ValType> *AVLTree<ValType>::SingleLeftRotation(Node<ValType> *cur_node) {
   right_child->left_ = cur_node;
   SetHeight(cur_node, 3);
   cur_node->size_ = GetSize(cur_node->left_) + GetSize(cur_node->right_) + 1;
-  SetHeight(right_child, 2);
+  right_child->height_ = (GetHeight(right_child->right_) > cur_node->height_
+                              ? GetHeight(right_child->right_)
+                              : cur_node->height_) +
+                         1; //
   right_child->size_ = GetSize(right_child->right_) + cur_node->size_ + 1;
   return right_child;
 }
@@ -94,10 +100,12 @@ Node<ValType> *AVLTree<ValType>::FindNode(Node<ValType> *cur_node,
     return NULL;
   } else if (cur_node->key_ == key) {
     return cur_node;
-  } else if (cur_node->key_ > key) {
+  } else if (cur_node->left_ != NULL && cur_node->key_ > key) {
     return FindNode(cur_node->left_, key);
-  } else if (cur_node->key_ < key) {
+  } else if (cur_node->right_ != NULL && cur_node->key_ < key) {
     return FindNode(cur_node->right_, key);
+  } else {
+    return NULL;
   }
 }
 

--- a/src/erase.cpp
+++ b/src/erase.cpp
@@ -96,7 +96,5 @@ Node<ValType> *AVLTree<ValType>::EraseNode(Node<ValType> *cur_node,
   return cur_node;
 }
 
-template <typename ValType> class AVLTree;
-template <typename ValType> class Node;
 template class AVLTree<int>;
 template class Node<int>;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,7 +1,4 @@
 #include "set.h"
-// #include "avl_tree.cpp"
-// #include "node.cpp"
-// #include "set.cpp"
 #include <iostream>
 using namespace std;
 

--- a/src/node.cpp
+++ b/src/node.cpp
@@ -56,5 +56,4 @@ void Node<ValType>::SetHeight(int height) {
 template<typename ValType>
 int Node<ValType>::GetHeight() { return height_; }
 
-template <typename ValType> class Node;
 template class Node<int>;

--- a/src/set.cpp
+++ b/src/set.cpp
@@ -55,7 +55,7 @@ template <typename ValType> int Set<ValType>::GetDepth(ValType key) {
   if (cur_node == NULL) {
     return 0;
   } else {
-    return bst_.FindDepth(bst_.root_, cur_node->key_, 0);
+    return bst_.FindDepth(bst_.root_, key, 0);
   }
 }
 // inset node with a given key
@@ -63,9 +63,10 @@ template <typename ValType> void Set<ValType>::Insert(ValType key) {
   bst_.num_of_nodes_++;
   bst_.root_ = bst_.InsertNode(bst_.root_, key);
 }
+
 // erase node matches a given key
 template <typename ValType> int Set<ValType>::Erase(ValType key) {
-  if (bst_.FindNode(bst_.root_, key)== NULL) {
+  if (bst_.FindNode(bst_.root_, key) == NULL) {
     return 0;
   } else {
     int depth = bst_.FindDepth(bst_.root_, key, 0);


### PR DESCRIPTION
두 개의 single rotation 함수(left, right)의 새로운 노드의 height 변경 부분을 삼항 연산자로 변경하였습니다.
기존의 함수로 height가 길어질 때의 예외 케이스를 처리하지 못했으며, 이를 삼항 연산자로 수정하여 예외를 처리하고 돔저지에서 correct 결과를 받았습니다.

FindNode 함수의 가독성을 위해 조건문 부분을 수정하였습니다. 